### PR TITLE
feat: Add support for postgres_backup_databases_custom, fixes #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,5 +56,5 @@ postgres_backup_connection_password: ""
 postgres_backup_postgres_data_path: ""
 # Alternatively, you'd need to configure `postgres_backup_container_image_to_use`.
 
-postgres_backup_databases: ['first', 'second', 'third']
+postgres_backup_databases_auto: ['first', 'second', 'third']
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,7 +39,17 @@ postgres_backup_healthcheck_port: "8080"
 postgres_backup_timezone: 'UTC'
 
 # postgres_backup_databases contains a list of database names to back up
-postgres_backup_databases: []
+# DO NOT set this variable directly, instead use postgres_backup_databases_auto or postgres_backup_databases_custom
+postgres_backup_databases: "{{ postgres_backup_databases_auto + postgres_backup_databases_custom }}"
+
+# The variable postgres_backup_databases_auto can be used by playbooks to automatically set the databases to back up
+# E.g. the mash-playbook automatically sets up postgres databases for services that need them.
+# It therefore makes sense to automatically add them to this variable.
+postgres_backup_databases_auto: []
+
+# postgres_backup_databases_custom is there if you want to manually add databases to the backup
+# e.g. because their setup is not controlled by ansible
+postgres_backup_databases_custom: []
 
 # Specifies where the Postgres data is.
 #


### PR DESCRIPTION
Fixes #5 

Should not break anything using this role as the variable `postgres_backup_databases` still can be directly set, although it shouldn't